### PR TITLE
Add 2 LexiconEditor's settings : topic and language

### DIFF
--- a/assets/components/lexiconeditor/js/mgr/widgets/entries.grid.js
+++ b/assets/components/lexiconeditor/js/mgr/widgets/entries.grid.js
@@ -7,8 +7,8 @@ LexiconEditor.grid.Entries = function(config) {
         ,baseParams: {
             action: 'workspace/lexicon/getList'
             ,'namespace': LexiconEditor.config.namespace
-            ,topic: ''
-            ,language: MODx.config.manager_language || 'en'
+            , 'topic': LexiconEditor.config.topic
+            , 'language': LexiconEditor.config.language
         }
         ,fields: ['name','value','namespace','topic','language','editedon','overridden']
         ,paging: true
@@ -44,12 +44,14 @@ LexiconEditor.grid.Entries = function(config) {
             ,name: 'language'
             ,id: 'modx-lexicon-filter-language'
             ,itemId: 'language'
-            ,value: MODx.config.manager_language || 'en'
+            ,value: LexiconEditor.config.language
             ,width: 100
             ,url: MODx.config.connector_url
             ,baseParams: {
                 action: 'system/language/getlist'
                 ,'namespace': LexiconEditor.config.namespace
+                ,'topic': LexiconEditor.config.topic
+                ,'language': LexiconEditor.config.language
             }
             ,listeners: {
                 'select': {fn:this.changeLanguage,scope:this}


### PR DESCRIPTION
This PR permit to set 2 news settings : lexiconeditor.topic and lexiconeditor.language to also set the topic and the preferred language by default.
It's globally working after create manually the key settings but it's not a finalized pull request (I'm not a real developer !).
What's missing or need to fix :
- automate the key settings creation during addon installation/upgrade
- there is something buggy with the Clear filter button : 
   * first click on it, the values are reset correctly
   * switching again the language is buggy : I get error "Processor not found: mgr/lexiconeditor/getlist"
- I'm not sure to had correctly implement the fallback default values